### PR TITLE
Fix empty categories and forums

### DIFF
--- a/src/Console/ImportFromFluxBB.php
+++ b/src/Console/ImportFromFluxBB.php
@@ -85,6 +85,7 @@ class ImportFromFluxBB extends AbstractCommand
     protected function fire()
     {
         ini_set('memory_limit', '16G');
+        define('CAT_INCREMENT', 500);
 
         $this->initialCleanup->execute($this->output);
         $this->users->execute($this->output, $this->input->getArgument('fluxbb-database'));

--- a/src/Importer/Categories.php
+++ b/src/Importer/Categories.php
@@ -43,7 +43,7 @@ class Categories
                 ->table('tags')
                 ->insert(
                     [
-                        'id' => $category->id,
+                        'id' => $category->id+CAT_INCREMENT,
                         'name' => $category->cat_name,
                         'slug' => Str::slug(preg_replace('/\.+/', '-', $category->cat_name), '-', 'de'),
                         'position' => $category->disp_position,
@@ -73,7 +73,7 @@ class Categories
             ->total_topics;
     }
 
-    private function getLastPostId(int $categoryId): int
+    private function getLastPostId(int $categoryId): ?int
     {
         return $this->database
             ->table($this->fluxBBDatabase . '.forums')
@@ -85,7 +85,7 @@ class Categories
             ->last_post_id;
     }
 
-    private function getLastPostedAt(int $categoryId): int
+    private function getLastPostedAt(int $categoryId): ?int
     {
         return $this->database
             ->table($this->fluxBBDatabase . '.forums')
@@ -97,7 +97,7 @@ class Categories
             ->last_post;
     }
 
-    private function getLastTopicId(int $categoryId): int
+    private function getLastTopicId(int $categoryId): ?int
     {
         $lastPostId = $this->getLastPostId($categoryId);
 

--- a/src/Importer/Forums.php
+++ b/src/Importer/Forums.php
@@ -58,7 +58,7 @@ class Forums
                         'slug' => Str::slug(preg_replace('/\.+/', '-', $forum->forum_name), '-', 'de'),
                         'description' => $forum->forum_desc,
                         'position' => $forum->disp_position,
-                        'parent_id' => $forum->cat_id,
+                        'parent_id' => $forum->cat_id+CAT_INCREMENT,
                         'discussion_count' => $forum->num_topics,
                         'last_posted_at' => (new \DateTime())->setTimestamp($forum->last_post),
                         'last_posted_discussion_id' => $this->getLastTopicId($forum->last_post_id),
@@ -74,7 +74,7 @@ class Forums
         $output->writeln('');
     }
 
-    private function getLastTopicId(int $lastPostId): ?int
+    private function getLastTopicId(?int $lastPostId): ?int
     {
         $topic = $this->database
             ->table($this->fluxBBDatabase . '.posts')
@@ -86,7 +86,7 @@ class Forums
         return $topic->topic_id ?? null;
     }
 
-    private function getLastPostUserId(int $lastPostId): ?int
+    private function getLastPostUserId(?int $lastPostId): ?int
     {
         $topic = $this->database
             ->table($this->fluxBBDatabase . '.posts')

--- a/src/Importer/Topics.php
+++ b/src/Importer/Topics.php
@@ -147,14 +147,14 @@ class Topics
 
     private function getParentTagId(int $tagId): int
     {
-        $user = $this->database
+        $forums = $this->database
             ->table($this->fluxBBDatabase . '.forums')
             ->select(['cat_id'])
             ->where('id', '=', $tagId)
             ->get()
             ->first();
 
-        return $user->cat_id;
+        return $forums->cat_id+CAT_INCREMENT;
     }
 
     private function createSolvedTag(): int


### PR DESCRIPTION
Hi,

on fedora-fr.org, I use a category for trash. Currently this category is empty and I observe an error:

```
TypeError: Return value of ArchLinux\ImportFluxBB\Importer\Categories::getLastTopicId() must be of the type int, null returned in /home/llaumgui/public_html/flarum/vendor/archlinux-de/flarum-import-fluxbb/src/Importer/Categories.php on line 111
```

This patch solve this issue.

This patch had also a hack to prevent issues between categories and forums with same id.
I use an increment... It's not the best solution but it's a quick solution to prevent constraint violation.